### PR TITLE
Optimize benchmark lookup

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -32,12 +32,14 @@ index = pc.Index(INDEX_NAME)
 with open("benchmarks.json", "r") as f:
     DATA = json.load(f)["benchmarks"]
 
+# Build a mapping from lowercase benchmark name to the benchmark data for
+# constant-time lookup when retrieving a benchmark by name.
+BENCHMARK_MAP = {bench["name"].lower(): bench for bench in DATA}
+
 
 def get_benchmark(name: str) -> Dict[str, Any] | None:
-    for bench in DATA:
-        if bench["name"].lower() == name.lower():
-            return bench
-    return None
+    """Return benchmark data by name using a pre-built map."""
+    return BENCHMARK_MAP.get(name.lower())
 
 
 def search_benchmarks(query: str, top_k: int = 3) -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- create a mapping of benchmark names to their data during startup
- use the map in `get_benchmark` for constant-time access

## Testing
- `python -m py_compile chatbot.py build_index.py`

------
https://chatgpt.com/codex/tasks/task_e_6883f670a8f48332b4ea6ec921432783