### PR TITLE
Add Pinecone filter support to search function

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,7 @@ After the index is built, start the chatbot:
 python chatbot.py
 ```
 
+`search_benchmarks` accepts an optional `filters` dictionary to narrow results
+by metadata fields (e.g. `{ "region": "US", "pe_ratio": {"$gt": 20} }`).
+
 Set the following environment variables before running either script: `PINECONE_API_KEY`, `PINECONE_ENV`, and `OPENAI_API_KEY`.

--- a/system_prompt.txt
+++ b/system_prompt.txt
@@ -188,6 +188,7 @@ I cannot [specific limitation]. Please contact your Sales representative for [sp
 - If a user query contains slight variations (e.g., “S&P500” vs “S&P 500”), attempt common variations before escalating
 - Always cite the exact benchmark name from the dataset in your response
 - For blend calculations, reference the specific JSON entries used in the calculation
+- Searches may include metadata filters using keys like `region` or `pe_ratio`.
 
 **Calculation Rules for Blends:**
 


### PR DESCRIPTION
## Summary
- extend `search_benchmarks` with optional `filters` argument
- document filter usage in the README and system prompt
- update OpenAI function schema for new parameter
- forward new argument in `call_function`

## Testing
- `python -m py_compile chatbot.py build_index.py`

------
https://chatgpt.com/codex/tasks/task_e_68840fb6689c8332b58a1b319fcd7960