### PR TITLE
Add sleek Flask web UI for benchmark chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,13 @@ python chatbot.py
 by metadata fields (e.g. `{ "region": "US", "pe_ratio": {"$gt": 20} }`).
 
 Set the following environment variables before running either script: `PINECONE_API_KEY`, `PINECONE_ENV`, and `OPENAI_API_KEY`.
+
+## Web UI
+
+A simple Flask application provides a modern chat interface.
+Install additional dependencies and run the server:
+```bash
+pip install flask flask-session
+python app.py
+```
+Open your browser to `http://localhost:5000` to start chatting.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,90 @@
+import json
+import os
+from typing import Dict, Any
+
+from flask import Flask, render_template, request, jsonify, session
+from flask_session import Session
+
+import chatbot
+
+app = Flask(__name__)
+app.secret_key = os.getenv("FLASK_SECRET_KEY", "devsecret")
+app.config["SESSION_TYPE"] = "filesystem"
+Session(app)
+
+with open("benchmarks.json", "r") as f:
+    bench_data = json.load(f)["benchmarks"]
+
+filter_options: Dict[str, set[str]] = {}
+for bench in bench_data:
+    tags = bench.get("tags", {})
+    for k, v in tags.items():
+        if isinstance(v, list):
+            filter_options.setdefault(k, set()).update(v)
+        else:
+            filter_options.setdefault(k, set()).add(str(v))
+
+
+@app.route("/")
+def index():
+    options = {k: sorted(list(v)) for k, v in filter_options.items()}
+    return render_template("index.html", options=options)
+
+
+def process_message(user_message: str) -> str:
+    if "messages" not in session:
+        session["messages"] = [
+            {"role": "system", "content": chatbot.SYSTEM_PROMPT}
+        ]
+        session["resp_count"] = 0
+
+    messages = session["messages"]
+    resp_count = session["resp_count"]
+
+    messages.append({"role": "user", "content": user_message})
+    response = chatbot.client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=messages,
+        tools=[{"type": "function", "function": func} for func in chatbot.FUNCTIONS],
+        tool_choice="auto",
+    )
+    msg = response.choices[0].message
+    final = ""
+    if msg.tool_calls:
+        messages.append({"role": "assistant", "content": None, "tool_calls": msg.tool_calls})
+        for call in msg.tool_calls:
+            args = json.loads(call.function.arguments or "{}")
+            result = chatbot.call_function(call.function.name, args)
+            messages.append({
+                "role": "tool",
+                "tool_call_id": call.id,
+                "content": json.dumps(result)
+            })
+        follow = chatbot.client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=messages,
+        )
+        final = follow.choices[0].message.content
+    else:
+        final = msg.content or ""
+
+    resp_count += 1
+    if resp_count % 4 == 0:
+        final = f"{final}\n\n{chatbot.DISCLAIMER_TEXT}"
+
+    messages.append({"role": "assistant", "content": final})
+    session["messages"] = messages
+    session["resp_count"] = resp_count
+    return final
+
+
+@app.route("/chat", methods=["POST"])
+def chat_endpoint():
+    data = request.get_json(force=True)
+    user_message = data.get("message", "")
+    reply = process_message(user_message)
+    return jsonify({"response": reply})
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,50 @@
+document.getElementById('startBtn').addEventListener('click', () => {
+    document.getElementById('landing').classList.add('hidden');
+    document.getElementById('chat-container').classList.remove('hidden');
+});
+
+function appendMessage(text, cls){
+    const messages = document.getElementById('messages');
+    const div = document.createElement('div');
+    div.className = `message ${cls}`;
+    div.textContent = text;
+    messages.appendChild(div);
+    messages.scrollTop = messages.scrollHeight;
+}
+
+function sendMessage(msg){
+    if(!msg.trim()) return;
+    appendMessage(msg, 'user');
+    fetch('/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: msg })
+    })
+    .then(res => res.json())
+    .then(data => {
+        appendMessage(data.response, 'assistant');
+    });
+}
+
+document.getElementById('sendBtn').addEventListener('click', () => {
+    const input = document.getElementById('userInput');
+    sendMessage(input.value);
+    input.value = '';
+});
+
+document.getElementById('userInput').addEventListener('keypress', (e) => {
+    if(e.key === 'Enter'){
+        e.preventDefault();
+        document.getElementById('sendBtn').click();
+    }
+});
+
+document.getElementById('applyFilters').addEventListener('click', () => {
+    const selected = {};
+    document.querySelectorAll('.sidebar input[type=checkbox]:checked').forEach(cb => {
+        if(!selected[cb.name]) selected[cb.name] = [];
+        selected[cb.name].push(cb.value);
+    });
+    const msg = 'Show benchmarks matching ' + JSON.stringify(selected);
+    sendMessage(msg);
+});

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,75 @@
+body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+    background: #f5f7fa;
+}
+.landing {
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    background: #002f6c;
+    color: #fff;
+    text-align: center;
+}
+.landing button {
+    padding: 1em 2em;
+    border: none;
+    border-radius: 6px;
+    background: #00a5b3;
+    color: #fff;
+    font-size: 1.2em;
+    cursor: pointer;
+}
+.chat {
+    display: flex;
+    height: 100vh;
+}
+.hidden { display: none; }
+.sidebar {
+    width: 250px;
+    background: #e6ecf2;
+    padding: 1em;
+    overflow-y: auto;
+}
+.filter-group { margin-bottom: 1em; }
+.chatbox {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    background: #fff;
+}
+.messages {
+    flex: 1;
+    padding: 1em;
+    overflow-y: auto;
+}
+.input-area {
+    display: flex;
+    padding: 1em;
+    border-top: 1px solid #ddd;
+}
+#userInput {
+    flex: 1;
+    padding: 0.5em 1em;
+    border: 1px solid #ccc;
+    border-radius: 20px;
+}
+.send-btn {
+    background: #00a5b3;
+    color: #fff;
+    border: none;
+    border-radius: 20px;
+    width: 40px;
+    margin-left: 0.5em;
+    cursor: pointer;
+}
+.message.user {
+    text-align: right;
+    margin-bottom: 0.5em;
+}
+.message.assistant {
+    text-align: left;
+    margin-bottom: 0.5em;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Benchmark Chatbot</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+<div id="landing" class="landing">
+    <h1>Welcome to the Benchmark Assistant</h1>
+    <button id="startBtn">Start Chatting</button>
+</div>
+
+<div id="chat-container" class="chat hidden">
+    <div class="sidebar">
+        <h3>Filters</h3>
+        {% for key, values in options.items() %}
+        <div class="filter-group">
+            <h4>{{ key.replace('_', ' ').title() }}</h4>
+            {% for val in values %}
+            <label>
+                <input type="checkbox" name="{{ key }}" value="{{ val }}"> {{ val }}
+            </label>
+            {% endfor %}
+        </div>
+        {% endfor %}
+        <button id="applyFilters" class="send-btn">Apply Filters</button>
+    </div>
+    <div class="chatbox">
+        <div id="messages" class="messages"></div>
+        <div class="input-area">
+            <input id="userInput" type="text" placeholder="Type your message..." autocomplete="off">
+            <button id="sendBtn" class="send-btn">&#x2b06;</button>
+        </div>
+    </div>
+</div>
+
+<script src="{{ url_for('static', filename='app.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `app.py` flask server that reuses chatbot logic and stores session messages
- design `index.html` with landing page, sidebar filters and round text input
- add modern styles and JS helpers for sending chat messages
- document web UI usage

## Testing
- `python -m py_compile app.py chatbot.py build_index.py`

------
https://chatgpt.com/codex/tasks/task_e_688533853e18833287d3c31458bb5434