### PR TITLE
Add configurable disclaimer frequency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ by metadata fields (e.g. `{ "region": "US", "pe_ratio": {"$gt": 20} }`).
 
 Set the following environment variables before running either script: `PINECONE_API_KEY`, `PINECONE_ENV`, and `OPENAI_API_KEY`.
 
+Both the CLI and web chatbot append a disclaimer every **third** assistant response. The frequency can be changed by modifying `DISCLAIMER_FREQUENCY` in `chatbot.py`.
+
 ## Web UI
 
 A simple Flask application provides a modern chat interface.

--- a/app.py
+++ b/app.py
@@ -69,7 +69,7 @@ def process_message(user_message: str) -> str:
         final = msg.content or ""
 
     resp_count += 1
-    if resp_count % 4 == 0:
+    if resp_count % chatbot.DISCLAIMER_FREQUENCY == 0:
         final = f"{final}\n\n{chatbot.DISCLAIMER_TEXT}"
 
     messages.append({"role": "assistant", "content": final})

--- a/chatbot.py
+++ b/chatbot.py
@@ -26,6 +26,9 @@ DISCLAIMER_TEXT = (
     "No investment advice or account approval authority."
 )
 
+# How often to append the disclaimer to assistant responses
+DISCLAIMER_FREQUENCY = 3
+
 PINECONE_API_KEY = os.getenv("PINECONE_API_KEY", "YOUR_PINECONE_API_KEY")
 PINECONE_ENV = os.getenv("PINECONE_ENV", "YOUR_PINECONE_ENV")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "YOUR_OPENAI_API_KEY")
@@ -262,14 +265,14 @@ def chat():
             )
             final = follow.choices[0].message.content
             resp_count += 1
-            if resp_count % 4 == 0:
+            if resp_count % DISCLAIMER_FREQUENCY == 0:
                 final = f"{final}\n\n{DISCLAIMER_TEXT}"
             messages.append({"role": "assistant", "content": final})
             print(f"\nAssistant: {final}")
         else:
             final = msg.content or ""
             resp_count += 1
-            if resp_count % 4 == 0:
+            if resp_count % DISCLAIMER_FREQUENCY == 0:
                 final = f"{final}\n\n{DISCLAIMER_TEXT}"
             messages.append({"role": "assistant", "content": final})
             print(f"\nAssistant: {final}")


### PR DESCRIPTION
## Summary
- add `DISCLAIMER_FREQUENCY` constant to control how often disclaimer is appended
- use the constant in both CLI and Flask app
- document the frequency in README

## Testing
- `python -m py_compile chatbot.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68855e6451b48332a71f9dd062d13fb8