### PR TITLE
Update README with Flask usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ python chatbot.py
 by metadata fields (e.g. `{ "region": "US", "pe_ratio": {"$gt": 20} }`).
 
 Set the following environment variables before running either script: `PINECONE_API_KEY`, `PINECONE_ENV`, and `OPENAI_API_KEY`.
+The scripts automatically retry failed requests to OpenAI and Pinecone so transient errors won't stop a run.
 
 Both the CLI and web chatbot append a disclaimer every **third** assistant response. The frequency can be changed by modifying `DISCLAIMER_FREQUENCY` in `chatbot.py`.
 
@@ -32,6 +33,8 @@ A simple Flask application provides a modern chat interface.
 Install additional dependencies and run the server:
 ```bash
 pip install flask flask-session
+export FLASK_SECRET_KEY=some-long-random-string
 python app.py
 ```
+The `FLASK_SECRET_KEY` variable controls the session key. Set it before running the server for better security.
 Open your browser to `http://localhost:5000` to start chatting.


### PR DESCRIPTION
## Summary
- document FLASK_SECRET_KEY usage for running `app.py`
- note that OpenAI and Pinecone requests retry on failure

## Testing
- `python -m py_compile app.py build_index.py chatbot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885617d851c8332a5c5a6913597f4ad