### PR TITLE
Remove web UI references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,4 @@ by metadata fields (e.g. `{ "region": "US", "pe_ratio": {"$gt": 20} }`).
 Set the following environment variables before running either script: `PINECONE_API_KEY`, `PINECONE_ENV`, and `OPENAI_API_KEY`.
 The scripts automatically retry failed requests to OpenAI and Pinecone so transient errors won't stop a run.
 
-Both the CLI and web chatbot append a disclaimer every **third** assistant response. The frequency can be changed by modifying `DISCLAIMER_FREQUENCY` in `chatbot.py`.
-
-## Web UI
-
-A simple Flask application provides a modern chat interface.
-Install additional dependencies and run the server:
-```bash
-pip install flask flask-session
-export FLASK_SECRET_KEY=some-long-random-string
-python app.py
-```
-The `FLASK_SECRET_KEY` variable controls the session key. Set it before running the server for better security.
-Open your browser to `http://localhost:5000` to start chatting.
+The chatbot appends a disclaimer every **third** assistant response. The frequency can be changed by modifying `DISCLAIMER_FREQUENCY` in `chatbot.py`.


### PR DESCRIPTION
## Summary
- remove instructions for running Flask UI
- tidy up documentation around disclaimers

## Testing
- `python -m py_compile build_index.py chatbot.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_6885656303a88332b444d93225d98a4f