### PR TITLE
Add LangGraph workflow for benchmark guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ After the index is built, start the chatbot:
 python chatbot.py
 ```
 
+Alternatively, you can experiment with a LangGraph-based workflow that routes
+questions through triage, minimum checks, or benchmark alternative logic:
+
+```bash
+python graph_agent.py
+```
+
 `search_benchmarks` accepts an optional `filters` dictionary to narrow results
 by metadata fields (e.g. `{ "region": "US", "pe_ratio": {"$gt": 20} }`).
 

--- a/build_index.py
+++ b/build_index.py
@@ -69,7 +69,7 @@ def main() -> None:
         items.append((bench["name"], vec, metadata))
 
     for i in range(0, len(items), 100):
-        index.upsert(items[i:i + 100])
+        index.upsert(items[i : i + 100])
 
     print(f"Upserted {len(items)} vectors to '{INDEX_NAME}'.")
 

--- a/chatbot.py
+++ b/chatbot.py
@@ -18,6 +18,7 @@ with open("system_prompt.txt", "r", encoding="utf-8") as f:
 # like:
 # "- Provide disclaimer every 3-4 interactions: *\u201cThis assistant ... authority.\u201d*"
 import re
+
 match = re.search(
     r"disclaimer every 3-4 interactions:\s*\*?[\"\u201c](.+?)[\"\u201d]\*?",
     SYSTEM_PROMPT,
@@ -63,14 +64,17 @@ def _with_retry(*, max_attempts: int = 3, **kwargs):
                 max_attempts,
                 exc,
             )
-            time.sleep(2 ** attempt)
+            time.sleep(2**attempt)
+
 
 def embed(text: str) -> List[float]:
     resp = client.embeddings.create(model=EMBEDDING_MODEL, input=text)
     return resp.data[0].embedding
 
 
-def num_tokens_from_messages(messages: List[Dict[str, Any]], model: str = CHAT_MODEL) -> int:
+def num_tokens_from_messages(
+    messages: List[Dict[str, Any]], model: str = CHAT_MODEL
+) -> int:
     """Return total token count for a list of chat messages."""
     try:
         encoding = tiktoken.encoding_for_model(model)
@@ -100,12 +104,16 @@ def num_tokens_from_messages(messages: List[Dict[str, Any]], model: str = CHAT_M
     return total_tokens
 
 
-def trim_history(messages: List[Dict[str, Any]], limit: int = MAX_MODEL_TOKENS - TOKEN_MARGIN) -> bool:
+def trim_history(
+    messages: List[Dict[str, Any]], limit: int = MAX_MODEL_TOKENS - TOKEN_MARGIN
+) -> bool:
     """Trim oldest user/assistant pairs until total tokens are under limit."""
     truncated = False
     while num_tokens_from_messages(messages) > limit and len(messages) > 1:
         # Find first user message after the system prompt
-        start = next((i for i, m in enumerate(messages) if i > 0 and m["role"] == "user"), None)
+        start = next(
+            (i for i, m in enumerate(messages) if i > 0 and m["role"] == "user"), None
+        )
         if start is None:
             break
         end = start + 1
@@ -115,6 +123,7 @@ def trim_history(messages: List[Dict[str, Any]], limit: int = MAX_MODEL_TOKENS -
         del messages[start:end]
         truncated = True
     return truncated
+
 
 INDEX_NAME = "benchmark-index"
 if INDEX_NAME not in pc.list_indexes().names():
@@ -181,12 +190,16 @@ def get_minimum(name: str, include_dividend: bool = False) -> Dict[str, Any]:
             "account_minimum": bench["account_minimum"],
         }
         if include_dividend:
-            result["dividend_yield"] = bench.get("fundamentals", {}).get("dividend_yield")
+            result["dividend_yield"] = bench.get("fundamentals", {}).get(
+                "dividend_yield"
+            )
         return result
     return {"error": f"Benchmark '{name}' not found"}
 
 
-def blend_minimum(allocations: List[Dict[str, Any]], include_dividend: bool = False) -> Dict[str, Any]:
+def blend_minimum(
+    allocations: List[Dict[str, Any]], include_dividend: bool = False
+) -> Dict[str, Any]:
     total_weight = sum(a.get("weight", 0) for a in allocations)
     if abs(total_weight - 1.0) > 1e-6:
         return {"error": f"weights sum to {total_weight}"}
@@ -220,7 +233,7 @@ FUNCTIONS = [
                 "top_k": {"type": "integer", "default": 3},
                 "filters": {
                     "type": "object",
-                    "description": "Optional metadata filters. Example: {\"pe_ratio\": {\"$gt\": 20}, \"region\": \"US\"}",
+                    "description": 'Optional metadata filters. Example: {"pe_ratio": {"$gt": 20}, "region": "US"}',
                 },
                 "include_dividend": {
                     "type": "boolean",
@@ -301,7 +314,9 @@ def call_function(name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
 
 def chat():
     messages = [{"role": "system", "content": SYSTEM_PROMPT}]
-    print("Hello! I'm here to assist with benchmark eligibility questions. How can I help you today?")
+    print(
+        "Hello! I'm here to assist with benchmark eligibility questions. How can I help you today?"
+    )
     resp_count = 0
     while True:
         user = input("\nUser: ")
@@ -319,7 +334,9 @@ def chat():
         msg = response.choices[0].message
         if msg.tool_calls:
             # Add the assistant message with tool calls first
-            messages.append({"role": "assistant", "content": None, "tool_calls": msg.tool_calls})
+            messages.append(
+                {"role": "assistant", "content": None, "tool_calls": msg.tool_calls}
+            )
             if trim_history(messages):
                 print("[Notice: conversation history truncated to fit token limit]")
 
@@ -330,11 +347,13 @@ def chat():
                 result = call_function(func_name, args)
 
                 # Add individual tool response
-                messages.append({
-                    "role": "tool",
-                    "tool_call_id": tool_call.id,
-                    "content": json.dumps(result)
-                })
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call.id,
+                        "content": json.dumps(result),
+                    }
+                )
                 if trim_history(messages):
                     print("[Notice: conversation history truncated to fit token limit]")
 

--- a/graph_agent.py
+++ b/graph_agent.py
@@ -1,0 +1,188 @@
+# LangGraph-based chatbot for benchmark guidance
+# This script sets up a simple LangGraph with triage, minimum check,
+# and benchmark alternative nodes. Each node calls the corresponding
+# agent logic defined in chatbot.py. The final node appends the
+# disclaimer from the system prompt.
+
+from __future__ import annotations
+
+from typing import Any, Dict
+import json
+
+from langgraph.graph import Graph
+
+import chatbot
+
+# Use the same system prompt and functions defined in chatbot.py
+SYSTEM_PROMPT = chatbot.SYSTEM_PROMPT
+DISCLAIMER_TEXT = chatbot.DISCLAIMER_TEXT
+DISCLAIMER_FREQUENCY = chatbot.DISCLAIMER_FREQUENCY
+
+
+# Keep a simple interaction counter for the disclaimer logic
+class InteractionCounter:
+    def __init__(self) -> None:
+        self.count = 0
+
+    def increment(self) -> bool:
+        self.count += 1
+        return self.count % DISCLAIMER_FREQUENCY == 0
+
+
+counter = InteractionCounter()
+
+# Helper to build a chat completion request using OpenAI
+client = chatbot.client
+
+
+def openai_chat(messages: list[dict[str, str]]) -> str:
+    response = chatbot._with_retry(
+        model=chatbot.CHAT_MODEL,
+        messages=messages,
+    )
+    return response.choices[0].message.content or ""
+
+
+# Node: Triage
+# Determine whether the user request is about minimum checks or
+# benchmark alternatives. The node outputs a string label.
+def triage_node(state: Dict[str, Any]) -> str:
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": state["input"]},
+        {
+            "role": "system",
+            "content": (
+                "Classify the request as 'minimum' if it asks about account "
+                "minimums, otherwise classify as 'alternative'. Respond with "
+                "just the label."
+            ),
+        },
+    ]
+    result = openai_chat(messages).strip().lower()
+    if "minimum" in result:
+        return "minimum"
+    return "alternative"
+
+
+# Node: Minimum checks
+# Use chatbot.get_minimum or blend_minimum depending on the request.
+def minimum_node(state: Dict[str, Any]) -> str:
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": state["input"]},
+    ]
+    response = chatbot.client.chat.completions.create(
+        model=chatbot.CHAT_MODEL,
+        messages=messages,
+        tools=[{"type": "function", "function": f} for f in chatbot.FUNCTIONS],
+        tool_choice="auto",
+    )
+    msg = response.choices[0].message
+    if msg.tool_calls:
+        messages.append(
+            {"role": "assistant", "content": None, "tool_calls": msg.tool_calls}
+        )
+        for tool_call in msg.tool_calls:
+            func_name = tool_call.function.name
+            args = json.loads(tool_call.function.arguments or "{}")
+            result = chatbot.call_function(func_name, args)
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_call.id,
+                    "content": json.dumps(result),
+                }
+            )
+        follow = chatbot.client.chat.completions.create(
+            model=chatbot.CHAT_MODEL,
+            messages=messages,
+        )
+        return follow.choices[0].message.content or ""
+    return msg.content or ""
+
+
+# Node: Benchmark alternatives
+# Use chatbot.search_benchmarks to recommend alternatives
+def alternative_node(state: Dict[str, Any]) -> str:
+    prompt = (
+        "The user request may require recommending alternative benchmarks."
+        " Use your data and search_benchmarks function to provide guidance."
+    )
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": state["input"]},
+        {"role": "system", "content": prompt},
+    ]
+    response = chatbot.client.chat.completions.create(
+        model=chatbot.CHAT_MODEL,
+        messages=messages,
+        tools=[{"type": "function", "function": f} for f in chatbot.FUNCTIONS],
+        tool_choice="auto",
+    )
+    msg = response.choices[0].message
+    if msg.tool_calls:
+        messages.append(
+            {"role": "assistant", "content": None, "tool_calls": msg.tool_calls}
+        )
+        for tool_call in msg.tool_calls:
+            func_name = tool_call.function.name
+            args = json.loads(tool_call.function.arguments or "{}")
+            result = chatbot.call_function(func_name, args)
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_call.id,
+                    "content": json.dumps(result),
+                }
+            )
+        follow = chatbot.client.chat.completions.create(
+            model=chatbot.CHAT_MODEL,
+            messages=messages,
+        )
+        return follow.choices[0].message.content or ""
+    return msg.content or ""
+
+
+# Node: Final output with disclaimer handling
+
+
+def output_node(state: Dict[str, Any]) -> Dict[str, Any]:
+    text = state["result"]
+    if counter.increment():
+        text = f"{text}\n\n{DISCLAIMER_TEXT}"
+    return {"output": text}
+
+
+# Build the graph
+def build_graph() -> Graph:
+    graph = Graph()
+    graph.add_node("triage", triage_node)
+    graph.add_node("minimum", minimum_node)
+    graph.add_node("alternative", alternative_node)
+    graph.add_node("output", output_node)
+
+    # Edges
+    graph.add_edge("triage", "minimum", condition=lambda x: x == "minimum")
+    graph.add_edge("triage", "alternative", condition=lambda x: x == "alternative")
+    graph.add_edge("minimum", "output")
+    graph.add_edge("alternative", "output")
+    graph.set_entry_point("triage")
+    return graph
+
+
+def run_chat(query: str) -> str:
+    graph = build_graph()
+    result = graph.invoke({"input": query})
+    return result["output"]
+
+
+if __name__ == "__main__":
+    while True:
+        try:
+            q = input("User: ")
+        except EOFError:
+            break
+        if not q:
+            continue
+        print(run_chat(q))


### PR DESCRIPTION
## Summary
- add `graph_agent.py` implementing a LangGraph workflow with triage, minimum check and alternative nodes
- document the new `graph_agent.py` script in the README
- format existing scripts with black

## Testing
- `ruff check .`
- `black . --check`
- `pytest -q`
- `pip install langgraph` *(fails: Could not find a version due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6886ed7a2fc08332aaa8fc3a64be1395