### PR TITLE
Add prompt files and loader module

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -1,0 +1,16 @@
+"""Load prompt files used by the chatbot."""
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent
+
+
+def _load(name: str) -> str:
+    path = BASE_DIR / name
+    with path.open("r", encoding="utf-8") as f:
+        return f.read()
+
+
+SYSTEM_PROMPT = _load("system_prompt.txt")
+TRIAGE_PROMPT = _load("triage_prompt.txt")
+MINIMUM_PROMPT = _load("minimum_prompt.txt")
+ALTERNATIVE_PROMPT = _load("alternative_prompt.txt")

--- a/alternative_prompt.txt
+++ b/alternative_prompt.txt
@@ -1,0 +1,4 @@
+# Alternative Prompt
+When a user's portfolio does not meet a benchmark's minimum, suggest eligible alternatives from the dataset.
+Never guess outside the dataset; cite only benchmarks present.
+Conclude with the disclaimer: "This assistant provides benchmark eligibility guidance only. No investment advice or account approval authority."

--- a/chatbot.py
+++ b/chatbot.py
@@ -9,9 +9,13 @@ import time
 from pinecone import Pinecone
 from openai import OpenAI
 
-# Load the large system prompt from an external file for readability
-with open("system_prompt.txt", "r", encoding="utf-8") as f:
-    SYSTEM_PROMPT = f.read()
+# Load the large system prompt and specialized prompts
+from agents import (
+    SYSTEM_PROMPT,
+    TRIAGE_PROMPT,
+    MINIMUM_PROMPT,
+    ALTERNATIVE_PROMPT,
+)
 
 # Extract the disclaimer text from the system prompt so it can be
 # appended to responses in the chat loop. The line in the prompt looks

--- a/minimum_prompt.txt
+++ b/minimum_prompt.txt
@@ -1,0 +1,4 @@
+# Minimum Prompt
+Provide the minimum account requirement for the specified benchmark based on the JSON dataset.
+If the benchmark is not found, follow dataset rules and escalate instead of estimating.
+End with: "This assistant provides benchmark eligibility guidance only. No investment advice or account approval authority."

--- a/triage_prompt.txt
+++ b/triage_prompt.txt
@@ -1,0 +1,6 @@
+# Triage Prompt
+When a request is ambiguous or outside your scope, gather clarifying details or escalate to Sales.
+Follow the dataset rules:
+- ONLY use information from the authorized JSON benchmark dataset.
+- Escalate if a benchmark is missing or unclear; never guess.
+Always include this disclaimer when required: "This assistant provides benchmark eligibility guidance only. No investment advice or account approval authority."


### PR DESCRIPTION
## Summary
- add triage_prompt.txt, minimum_prompt.txt, and alternative_prompt.txt
- create agents.py to load all prompts
- import prompts from agents.py in chatbot

## Testing
- `python -m py_compile chatbot.py build_index.py agents.py`

------
https://chatgpt.com/codex/tasks/task_e_6886ed76d64c8332a87005acbe8ea590